### PR TITLE
Add new files and directories to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,8 @@ user_projects/*
 !user_projects/empty.txt
 Studio.zip
 /studio
+.venv/
+.python-version
+get_studio.py
+requirements.txt
+output/


### PR DESCRIPTION
This pull request updates the `.gitignore` file to exclude files and directories created by PhysiCell Studio when it's installed in the same root directory as the main PhysiCell project.  This prevents these Studio-specific files from being accidentally tracked by Git and included in the PhysiCell repository.

**Specifically, this PR ignores the following:**
    * .venv/
    * .python-version
    * get_studio.py
    * requirements.txt
    * output/ - this is not specific to studio, but wanted to make sure the output/ directory is not committed.

**Reasoning:**

PhysiCell Studio is a separate application from the core PhysiCell simulation engine.  Its configuration files, build artifacts, temporary files, and potentially user-specific data should not be part of the PhysiCell codebase. Keeping these files out of the repository:

*   **Keeps the repository clean:** Avoids cluttering the project with irrelevant files.
*   **Prevents accidental commits:** Reduces the risk of developers accidentally committing large binary files or sensitive configuration data.
*   **Reduces repository size:** Keeps the repository smaller and faster to clone.
*  **Avoids merge conflicts** Avoids merge conflicts due to changes in the binary files.
